### PR TITLE
select columns for translating data

### DIFF
--- a/R/DataDictionary.R
+++ b/R/DataDictionary.R
@@ -895,7 +895,7 @@ DataDictionary <- R6Class(
 
     },
 
-    translate_data = function(x, ...,
+    translate_data = function(x, .cols,
                               units,
                               warn_unmatched,
                               apply_variable_labels,
@@ -904,7 +904,7 @@ DataDictionary <- R6Class(
                               drop_unused_levels){
 
       overlapping_variables <- self |>
-        infer_overlapping_variables(x, warn_unmatched)
+        infer_overlapping_variables(x[.cols], warn_unmatched)
 
       unit_variables <- overlapping_variables |>
         intersect(self$get_names_with_units())

--- a/R/translate.R
+++ b/R/translate.R
@@ -24,9 +24,12 @@
 #'
 #' @param ... Additional arguments passed to the `translate` method.
 #'
-#' - For `translate_data`, nothing happens at the moment. Eventually
-#'   this `...` will be used to select which columns to translate. The
-#'   default will be `everything()`.
+#' - For `translate_data`, `...` uses
+#'   [tidyselect](https://tidyselect.r-lib.org/reference/language.html)
+#'   to choose which columns to translate. Any tidyselect expression is
+#'   accepted (e.g., `starts_with("age")`, `c(sex, bmi)`). When `...` is
+#'   empty the default is `everything()`, i.e. all columns in `x` are
+#'   considered for translation.
 #'
 #' - For `translate_names`, `...` must contain name-value pairs. The name can
 #'   be any value in `x` and the corresponding value indicates what to
@@ -125,6 +128,14 @@
 #'
 #' attr(out2$age_years, "label") # "Age of participant, per 10 years"
 #'
+#' # Translate only the age_years column (gender left unchanged)
+#' out3 <- translate_data(
+#'   dat, dictionary = dd,
+#'   age_years
+#' )
+#' attr(out3$age_years, "label") # "Age of participant"
+#' attr(out3$gender, "label")    # NULL
+#'
 #' # Replace variable names with labels (useful after pivot_longer)
 #' translate_names(c("age_years", "gender"), dictionary = dd)
 #'
@@ -135,6 +146,8 @@
 #' [data_dictionary()], [as_data_dictionary()], [set_default_dictionary()]
 #'
 #' @importFrom checkmate assert_character assert_choice assert_logical
+#' @importFrom rlang expr
+#' @importFrom tidyselect eval_select
 #'
 #' @export
 #'
@@ -154,8 +167,15 @@ translate_data <- function(x, ...,
   assert_logical(apply_variable_labels, len = 1)
   assert_logical(apply_category_labels, len = 1)
 
+  .cols <- if (...length() == 0L) {
+    names(x)
+  } else {
+    names(eval_select(expr(c(...)), data = x))
+  }
+
   infer_meta(dictionary)$translate_data(
-    x = x, ...,
+    x = x,
+    .cols = .cols,
     units = units,
     warn_unmatched = warn_unmatched,
     apply_variable_labels = apply_variable_labels,

--- a/man/translate_data.Rd
+++ b/man/translate_data.Rd
@@ -51,9 +51,12 @@ character/factor.
 
 \item{...}{Additional arguments passed to the \code{translate} method.
 \itemize{
-\item For \code{translate_data}, nothing happens at the moment. Eventually
-this \code{...} will be used to select which columns to translate. The
-default will be \code{everything()}.
+\item For \code{translate_data}, \code{...} uses
+\href{https://tidyselect.r-lib.org/reference/language.html}{tidyselect}
+to choose which columns to translate. Any tidyselect expression is
+accepted (e.g., \code{starts_with("age")}, \code{c(sex, bmi)}). When \code{...} is
+empty the default is \code{everything()}, i.e. all columns in \code{x} are
+considered for translation.
 \item For \code{translate_names}, \code{...} must contain name-value pairs. The name can
 be any value in \code{x} and the corresponding value indicates what to
 translate \code{x} to. This can be used  to overrule the value that the
@@ -180,6 +183,14 @@ out2 <- translate_data(
 out2$age_years # now 5.5 (i.e., 55 / 10)
 
 attr(out2$age_years, "label") # "Age of participant, per 10 years"
+
+# Translate only the age_years column (gender left unchanged)
+out3 <- translate_data(
+  dat, dictionary = dd,
+  age_years
+)
+attr(out3$age_years, "label") # "Age of participant"
+attr(out3$gender, "label")    # NULL
 
 # Replace variable names with labels (useful after pivot_longer)
 translate_names(c("age_years", "gender"), dictionary = dd)

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -226,3 +226,69 @@ test_that(
   }
 )
 
+test_that(
+  "translate_data column selection with ...",
+  code = {
+
+    # Single column selected: only that column gets translated
+    out <- translate_data(data_test, number, dictionary = dd_test_filled)
+
+    expect_equal(attr(out$number, "label"), "A number")
+    expect_null(attr(out$integer, "label"))
+    expect_null(attr(out$character, "label"))
+
+    # Two columns selected: only those columns translated
+    out2 <- translate_data(
+      data_test,
+      number, character,
+      dictionary = dd_test_filled
+    )
+
+    expect_equal(attr(out2$number, "label"), "A number")
+    expect_equal(attr(out2$character, "label"), "A character")
+    expect_null(attr(out2$integer, "label"))
+    expect_null(attr(out2$factor, "label"))
+
+    # Selected column data (character) is recoded; unselected (factor) is not
+    expect_equal(levels(out2$character), dd_test_filled$get_category_labels("character"))
+    # factor column was not translated: its levels are the original input levels
+    expect_equal(levels(out2$factor), levels(data_test$factor))
+
+    # tidyselect helpers work (starts_with)
+    out3 <- translate_data(
+      data_test,
+      starts_with("num"),
+      dictionary = dd_test_filled
+    )
+
+    expect_equal(attr(out3$number, "label"), "A number")
+    expect_null(attr(out3$integer, "label"))
+
+    # Empty ... defaults to everything(): all columns translated
+    out_all <- translate_data(data_test, dictionary = dd_test_filled)
+
+    expect_equal(
+      purrr::map_chr(out_all, ~ attr(.x, "label")),
+      c(
+        number = "A number",
+        integer = "An integer",
+        logical = "A logical",
+        character = "A character",
+        factor = "A factor",
+        date = "A date"
+      )
+    )
+
+    # warn_unmatched only fires for selected columns, not unselected ones
+    expect_no_warning(
+      translate_data(
+        data_test,
+        number,
+        dictionary = dd_test_filled,
+        warn_unmatched = TRUE
+      )
+    )
+
+  }
+)
+


### PR DESCRIPTION
- translate_data() now accepts tidyselect expressions in ... to specify which columns to translate. Default (empty ...) is everything().
- DataDictionary$translate_data() receives resolved column names as .cols instead of forwarding .... infer_overlapping_variables() is called on the selected subset so warn_unmatched only fires for selected columns.
- Added @importFrom rlang expr and tidyselect eval_select to translate_data().
- Updated roxygen docs and examples for translate_data ... parameter.
- Added tests covering: single-column select, multi-column select, tidyselect helper (starts_with), default everything() behaviour, and warn_unmatched scoping to selected columns only.